### PR TITLE
fetch 성능 높이기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// 재시도 처리
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/holiday_hub/HolidayHubApplication.java
+++ b/src/main/java/com/example/holiday_hub/HolidayHubApplication.java
@@ -2,8 +2,10 @@ package com.example.holiday_hub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableRetry
 @EnableScheduling
 @SpringBootApplication
 public class HolidayHubApplication {

--- a/src/main/java/com/example/holiday_hub/configuration/RestClientConfig.java
+++ b/src/main/java/com/example/holiday_hub/configuration/RestClientConfig.java
@@ -3,10 +3,12 @@ package com.example.holiday_hub.configuration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestClient;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 
 @Configuration
@@ -14,7 +16,10 @@ public class RestClientConfig {
 
     @Bean
     public RestClient restClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setReadTimeout(Duration.ofSeconds(3));
         return RestClient.builder()
+                .requestFactory(factory)
                 .messageConverters(converter -> converter.add(createJsonConverter()))
                 .build();
     }

--- a/src/main/java/com/example/holiday_hub/initializer/HolidayApiClient.java
+++ b/src/main/java/com/example/holiday_hub/initializer/HolidayApiClient.java
@@ -5,6 +5,9 @@ import com.example.holiday_hub.dto.HolidayInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -18,6 +21,10 @@ public class HolidayApiClient {
     static final String BASE_URL = "https://date.nager.at/api/v3";
     private final RestClient restClient;
 
+    @Retryable(
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 1000L)
+    )
     public List<CountryInfoDto> fetchCountries() {
         return restClient.get()
                 .uri(BASE_URL + "/AvailableCountries")
@@ -26,6 +33,10 @@ public class HolidayApiClient {
                 });
     }
 
+    @Retryable(
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 1000L)
+    )
     public List<HolidayInfoDto> fetchHolidays(int year, String countryCode) {
         return restClient.get()
                 .uri(BASE_URL + "/PublicHolidays" + "/{year}/{countryCode}", year, countryCode)
@@ -33,4 +44,17 @@ public class HolidayApiClient {
                 .body(new ParameterizedTypeReference<>() {
                 });
     }
+
+    @Recover
+    public List<HolidayInfoDto> recover(Exception e, int year, String countryCode) {
+        log.error("[fetchHoliday]Retry 실패 year = {} countryCode={}", year, countryCode);
+        return List.of();
+    }
+
+    @Recover
+    public List<CountryInfoDto> recover(Exception e) {
+        log.error("[fetchCountries]Retry 실패");
+        return List.of();
+    }
+
 }

--- a/src/main/java/com/example/holiday_hub/initializer/HolidaySyncInitializer.java
+++ b/src/main/java/com/example/holiday_hub/initializer/HolidaySyncInitializer.java
@@ -14,6 +14,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 @Slf4j
 @Component
@@ -31,22 +34,41 @@ public class HolidaySyncInitializer {
     @Transactional
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady() {
-        syncAll(fromYear, toYear);
+        List<String> countryCodes = syncCountry();
+        syncAll(countryCodes, fromYear, toYear);
     }
 
-    public void syncAll(int fromYear, int toYear) {
-        // TODO: 속도 개선 작업 REFACTORING 필요
+    public void syncAll(List<String> countryCodes, int fromYear, int toYear) {
+        ExecutorService excutor = Executors.newFixedThreadPool(20);
+        List<Future<List<HolidayInfoDto>>> futures = new ArrayList<>();
+
+        for (int year = fromYear; year <= toYear; year++) {
+            for (String countryCode : countryCodes) {
+                final int finalYear = year;
+                futures.add(excutor.submit(() -> client.fetchHolidays(finalYear, countryCode)));
+            }
+            log.info("{}년 fetch 요청", year);
+        }
+
+        List<HolidayInfoDto> holidayInfoDtos = new ArrayList<>();
+        for (Future<List<HolidayInfoDto>> future : futures) {
+            try {
+                holidayInfoDtos.addAll(future.get()); // future 작업 마칠 때까지 대기
+            } catch (Exception e) {
+                log.warn("공휴일 정보 조회 실패", e);
+            }
+
+        }
+        excutor.shutdown();
+        holidayInfoRepository.saveAll(holidayInfoDtos.stream().map(HolidayInfoDto::toEntity).toList());
+        log.info("{}개 공휴일 DB 업데이트 성공", holidayInfoDtos.size());
+    }
+
+    public List<String> syncCountry() {
         List<CountryInfoDto> countriesDtos = client.fetchCountries();
         countryInfoRepository.saveAll(countriesDtos.stream().map(CountryInfoDto::toEntity).toList());
-        log.info("국가 정보 업로드 완료: {}개",countriesDtos.size());
-        List<HolidayInfoDto> holidayInfoDtos = new ArrayList<>();
-        for (int year = fromYear; year <= toYear; year++) {
-            for (CountryInfoDto country : countriesDtos) {
-                holidayInfoDtos.addAll(client.fetchHolidays(year, country.countryCode()));
-            }
-            log.info("{}년 정보 업데이트 완료", year);
-        }
-        holidayInfoRepository.saveAll(holidayInfoDtos.stream().map(HolidayInfoDto::toEntity).toList());
+        log.info("국가 정보 업로드 완료: {}개", countriesDtos.size());
+        return countriesDtos.stream().map(CountryInfoDto::countryCode).toList();
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,12 +21,13 @@ spring:
           batch_size: 100
         order_inserts: true
         format_sql: true
+#        generate_statistics: true
   h2:
     console:
       enabled: true
 support:
   year:
-    from: 2024
+    from: 2020
     to: 2025
 
 logging:


### PR DESCRIPTION
## 1. PR 내용
 -  fetch 작업을 비동기 작업으로 전환(기존 1년 117개국 기준 fetch하는데 소요시간 20초 이상으로 6년을 했을 경우 2분 이상이 소요되었음)
 -  전환 후 5초 이내로 단축
 - fetch 실패의 경우 2회 재처리 시도
 - ReadTimeOut을 걸어 3초 이상 연결이 지속될 경우 해당 연결을 끊도록 진행

## 2. Check List
 - [x] 재처리 로직 정상 동작 확인
 - [x] mock 서버 생성 후 값 확인하기

